### PR TITLE
Hotfix/apiversion

### DIFF
--- a/ARM-template/components/controllerNode.json
+++ b/ARM-template/components/controllerNode.json
@@ -270,7 +270,7 @@
             }
         },
         {
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2016-09-01",
             "name": "virtualMachine",
             "type": "Microsoft.Resources/deployments",
             "dependsOn": [

--- a/ARM-template/mainTemplate.json
+++ b/ARM-template/mainTemplate.json
@@ -262,7 +262,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "containerService",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -303,7 +303,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "storageAccount",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -323,7 +323,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "containerRegistry",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -340,7 +340,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "controllerNode",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [


### PR DESCRIPTION
Deploying our solution in marketplace will trigger such error:
```InvalidTemplateDeployment template validation failed: 'The template resource 'containerService' at line '264' and column '6' is invalid. The nested deployment has api-version '2017-05-10', which is not supported in api-version '2015-11-01' used to deploy the template. Please use api-version '2017-05-10' or later to deploy the template. Or use an older api-version for the nested deployment in the template. Please see https://aka.ms/arm-template/#resources for usage details.'.```

The validate url is `https://management.azure.com/subscriptions/2085065b-00f8-4cba-9675-ba15f4d4ab66/resourcegroups/aaaaa/providers/microsoft.resources/deployments/visualstudiochina.elk-on-kube-previewelk-on-kuber-20170811192201/validate?api-version=2015-11-01` which uses stale api-version. I have to change some components to the prior api-version in order to pass the validation.